### PR TITLE
Dev 6.5.9 bugfix

### DIFF
--- a/lib/plugins/dictionary.rb
+++ b/lib/plugins/dictionary.rb
@@ -34,9 +34,11 @@ module Cinch
         data = JSON.parse(open("http://api.wordnik.com:80/v4/word.json/#{word}/definitions?limit=2&includeRelated=true&sourceDictionaries=wiktionary&useCanonical=true&includeTags=false&api_key=86454404519fadebdb90e06ef9a04381b87e620884ad40abd").read)
         results = []
 
+        # @author David H. (doubledave) <devyo@sinsira.net>
+        # Made update to the below block of code.
         data.each do |i|
           definitiontextfield = i['text']
-          definitiontextfield = definitiontextfield.gsub(/<[^>]*>/ui,'')
+          definitiontextfield = definitiontextfield.gsub(/<[^>]*>/ui,'') # doubledave 8/24/2019 - This .gsub method removes html-style tags.
           results.push("%s: (%s) - %s" % [i['word'], i['partOfSpeech'], definitiontextfield])
         end
         return results

--- a/lib/plugins/dictionary.rb
+++ b/lib/plugins/dictionary.rb
@@ -34,8 +34,11 @@ module Cinch
         data = JSON.parse(open("http://api.wordnik.com:80/v4/word.json/#{word}/definitions?limit=2&includeRelated=true&sourceDictionaries=wiktionary&useCanonical=true&includeTags=false&api_key=86454404519fadebdb90e06ef9a04381b87e620884ad40abd").read)
         results = []
 
-        data.each{|i| results.push("%s: (%s) - %s" % [i['word'], i['partOfSpeech'], i['text']])}
-
+        data.each do |i|
+          definitiontextfield = i['text']
+          # TODO manipulate textfield here
+          results.push("s: (%s) - %s" % [i.['word'], i['partOfSpeech'], definitiontextfield])
+        end
         return results
       end
 

--- a/lib/plugins/dictionary.rb
+++ b/lib/plugins/dictionary.rb
@@ -36,8 +36,8 @@ module Cinch
 
         data.each do |i|
           definitiontextfield = i['text']
-          # TODO manipulate textfield here
-          results.push("s: (%s) - %s" % [i.['word'], i['partOfSpeech'], definitiontextfield])
+          definitiontextfield = definitiontextfield.gsub(/<[^>]*>/ui,'')
+          results.push("%s: (%s) - %s" % [i['word'], i['partOfSpeech'], definitiontextfield])
         end
         return results
       end

--- a/lib/plugins/dictionary.rb
+++ b/lib/plugins/dictionary.rb
@@ -35,10 +35,10 @@ module Cinch
         results = []
 
         # @author David H. (doubledave) <devyo@sinsira.net>
-        # Made update to the below block of code.
+        # 8/24/2019 - The below block contains the .gsub string method which removes html-style tags surrounded by < and >.
         data.each do |i|
           definitiontextfield = i['text']
-          definitiontextfield = definitiontextfield.gsub(/<[^>]*>/ui,'') # doubledave 8/24/2019 - This .gsub method removes html-style tags.
+          definitiontextfield = definitiontextfield.gsub(/<[^>]*>/ui,'')
           results.push("%s: (%s) - %s" % [i['word'], i['partOfSpeech'], definitiontextfield])
         end
         return results


### PR DESCRIPTION
File changed:
  lib/plugins/dictionary.rb
    Add code to strip out html-style tags from the text that is returned to the user such as \<xref\> and \</xref\>.  Resolved issue #113 

Edit: Typo correction